### PR TITLE
Add missing QDataStream include for qt5.6

### DIFF
--- a/qtsingleapplication/qtlocalpeer.h
+++ b/qtsingleapplication/qtlocalpeer.h
@@ -48,6 +48,7 @@
 #include <QtNetwork/QLocalServer>
 #include <QtNetwork/QLocalSocket>
 #include <QtCore/QDir>
+#include <QDataStream>
 
 namespace QtLP_Private {
 #include "qtlockedfile.h"


### PR DESCRIPTION
Without including QDataStream, build fails with
"error: variable 'QDataStream ds' has initializer but incomplete type"
